### PR TITLE
【修正】H1の見出しがH2より小さい件

### DIFF
--- a/app/assets/stylesheets/base/default.scss
+++ b/app/assets/stylesheets/base/default.scss
@@ -13,11 +13,6 @@ body {
   padding-top: 70px;
 }
 
-h1 {
-  font-size: 24px;
-  font-size: 2.4rem;
-}
-
 i {
   width: 26px;
 }

--- a/app/assets/stylesheets/scaffolds.scss
+++ b/app/assets/stylesheets/scaffolds.scss
@@ -64,16 +64,6 @@ div {
   margin-bottom: 20px;
   background-color: #f0f0f0;
 
-  h2 {
-    text-align: left;
-    font-weight: bold;
-    padding: 5px 5px 5px 15px;
-    font-size: 12px;
-    margin: -7px -7px 0;
-    background-color: #c00;
-    color: #fff;
-  }
-
   ul li {
     font-size: 12px;
     list-style: square;


### PR DESCRIPTION
修正:H1の見出しサイズがH2より小さいものを修正
issue  : #16 

## 原因

app/assets/stylesheets/base/default.scss
にてh1のサイズを指定していたことが原因だった。
こちら見出し関係のstyleシートを別途作成しまとめて行うように変更したいと考えている

修正自体は完了したため、Resolveマージとする。
<img width="1141" alt="2018-03-17 23 09 43" src="https://user-images.githubusercontent.com/19791597/37556365-53c792f6-2a38-11e8-961a-1caaa5d7ae20.png">
